### PR TITLE
Fix microseconds position.

### DIFF
--- a/lib/file/reader.py
+++ b/lib/file/reader.py
@@ -73,7 +73,7 @@ class StreamReader:
                 :return:
                 """
                 hd = header_line.split()
-                hd[0] = hd[0][:13] + '.' + hd[0][13:]  # make convertible to UTC format
+                hd[0] = hd[0][:14] + '.' + hd[0][14:]  # make convertible to UTC format
                 hd_time = UTCDateTime(hd[0])  # convert to UTC time format
                 new_data.start_time = hd_time  # set time
                 new_data.station = hd[1]


### PR DESCRIPTION
For example, 201109051828486782 was converted into 2011090518284.86782 instead 20110905182848.6782